### PR TITLE
Fix sirupsen import

### DIFF
--- a/quadlek/cointip.go
+++ b/quadlek/cointip.go
@@ -8,7 +8,7 @@ import (
 
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/jirwin/quadlek/quadlek"
 	"github.com/morgabra/cointip"
 )


### PR DESCRIPTION
This is preventing Bullpeen/quad from using go modules.